### PR TITLE
Tighten URL matching pattern

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,7 +1,7 @@
 exports.aceGetFilterStack = function(name, context){
   return [
     context.linestylefilter.getRegexpFilter(
-      new RegExp("http.+((\.[pP][nN][gG])|(\.[jJ][pP][gG])|(\.[gG][iI][fF])|(\.[jJ][pP][eE][gG])|(\.[bB][mM][pP])|(\.[sS][vV][gG]))", "g"), 'image')
+      new RegExp("\\bhttps?://\\S+\\.([pP][nN][gG]|[jJ][pP][eE]?[gG]|[gG][iI][fF]|[bB][mM][pP]|[sS][vV][gG])([?&;]\\S*|(?=\\s|$))", "g"), 'image')
   ];
 }
 


### PR DESCRIPTION
The previous pattern was too lenient and matched URLs like 'https://example.org/foojpgbar' and even non-URLs like 'httpexamplefoojpgbar' or 'http foo jpg'.

This new pattern is much stricter and has the following rules for matching:
* The URL must start with 'http://' or 'https://'.
* The intermediate part must not contain any whitespace.
* There must be an occurrence of '.png', '.jpg', '.jpeg', '.gif', '.bmp', or '.svg'.
* This occurrence must be followed by:
  * a question mark, ampersand, or semicolon, followed by any amount of non-whitespace (which indicate URL parameters, e.g. 'https://example.org/foo.jpg?version=1' or 'https://example.org/?file=foo.jpg&bar');
  * a whitespace; or
  * the end of the line.

---

Example pad showcasing the issues of the previous pattern: https://board.net/p/previewimages-issue

Some of this is due to the missing backslash escaping (which is required when the regular expression is in a string instead of a literal, i.e. `new RegExp("\\.")` is equivalent to `/\./`), which is what I first noticed as random YouTube channel URLs got a preview image in a pad because they contained e.g. `JPg` somewhere in the channel ID – not preceded by a dot, of course, and followed by more characters. However, the lack of URL parameter handling may also lead to previews failing, e.g. S3 URLs with signatures or when the URL includes a file version parameter, and whitespace is never allowed in URLs at all.

Of course, there is no one-size-fits-all solution for this, but I think the new pattern should work better than the old one at filtering out non-image URLs without excluding too many legitimate image URLs.

(Note: I could not test this inside Etherpad because I can't set up a dev instance right now, but I did test the pattern itself extensively on RegExr and with Node.js.)